### PR TITLE
chore: 하네스 리뷰 루프 추가 (#7)

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -11,6 +11,7 @@ This repo uses a small internal harness to turn product intent into repeatable i
 - `phases/`: step plans and state
 - `scripts/execute.py`: step executor
 - `scripts/verify.py`: lightweight repo verification
+- `phases/_review-prompt.md`: Claude review-only prompt used by `execute.py --review`
 
 ## Current Scope
 
@@ -23,6 +24,8 @@ It supports:
 - blocked/error state handling
 - context carry-forward through step summaries
 - independent acceptance-criteria checks
+- one optional Claude review after a successful phase execution
+- correction prompt artifact creation when the review finds blocking issues
 
 It does not support:
 
@@ -30,6 +33,8 @@ It does not support:
 - auto-learning systems
 - external hook frameworks
 - deployment automation
+- automatic correction implementation
+- automatic re-review
 
 ## Usage
 
@@ -45,7 +50,36 @@ Execute the first phase:
 python3 scripts/execute.py 0-foundation
 ```
 
+Execute a phase and then run one Claude review:
+
+```bash
+python3 scripts/execute.py 0-foundation --review
+```
+
+When `--review` is used, the executor first runs the normal `execute_phase(<phase>)` loop. If that loop fails, blocks, or errors, execution stops before review.
+
+On success, Claude performs one review pass only. The review is saved to:
+
+```text
+phases/<phase>/stepN-review.json
+```
+
+If Claude reports blocking issues, `execute.py` writes a Codex correction prompt to:
+
+```text
+phases/<phase>/stepN-correction-prompt.md
+```
+
+The correction prompt is for Codex to implement in one correction pass. Claude does not implement corrections, and the executor does not automatically run a second review. After applying a correction, rerun the step Acceptance Criteria and:
+
+```bash
+python3 scripts/verify.py
+```
+
+If Claude review output cannot be parsed, the raw output is saved under `non_blocking`, the verdict is treated as `pass`, and no correction prompt is created.
+
 ## Notes
 
 - `verify.py` is intentionally light for now.
 - Later phases can extend verification once real app commands exist.
+- Review artifacts are generated outputs for operating the harness loop.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -78,6 +78,8 @@ python3 scripts/verify.py
 
 If Claude review output cannot be parsed, the raw output is saved under `non_blocking`, the verdict is treated as `pass`, and no correction prompt is created.
 
+보정 후 Claude 리뷰를 다시 실행하려면 기존 `phases/<phase>/stepN-review.json` 파일을 삭제한 뒤 `scripts/execute.py <phase> --review`를 다시 실행한다.
+
 ## Notes
 
 - `verify.py` is intentionally light for now.

--- a/phases/_review-prompt.md
+++ b/phases/_review-prompt.md
@@ -1,0 +1,32 @@
+# Claude Harness Review Prompt
+
+You are reviewing one completed harness step.
+
+You must only review. Do not implement corrections. Do not edit files. Do not run a correction loop.
+
+Classify issues as blocking only when they meet one of these criteria:
+
+- typecheck, lint, or verification failure
+- files changed outside the step spec scope
+- forbidden behavior from the project rules or step spec
+- unimplemented Work item from the step spec
+- unmet Acceptance Criteria from the step spec
+
+Classify these as non-blocking:
+
+- naming suggestions
+- style suggestions
+- future refactoring ideas
+- accessibility or UX suggestions outside the current Acceptance Criteria
+
+Return exactly one JSON object and no prose:
+
+```json
+{
+  "verdict": "pass",
+  "blocking": [],
+  "non_blocking": []
+}
+```
+
+Use `"verdict": "needs_correction"` only when `blocking` is non-empty.

--- a/scripts/execute.py
+++ b/scripts/execute.py
@@ -22,6 +22,7 @@ ROOT = Path(__file__).resolve().parent.parent
 PHASES_DIR = ROOT / "phases"
 DOCS_DIR = ROOT / "docs"
 CLAUDE_FILE = ROOT / "CLAUDE.md"
+REVIEW_PROMPT_FILE = PHASES_DIR / "_review-prompt.md"
 VALID_STATUSES = {"pending", "completed", "error", "blocked"}
 MAX_RETRIES = 3
 
@@ -36,6 +37,10 @@ def read_json(path: Path) -> dict:
 
 def write_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def relative_path(path: Path) -> str:
+    return str(path.relative_to(ROOT))
 
 
 def load_guardrails() -> str:
@@ -88,6 +93,22 @@ def run_ac_commands(step_file: Path) -> tuple[bool, str]:
                 message += f"\n{output}"
             return False, message
     return True, ""
+
+
+def run_capture(command: list[str]) -> str:
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    output = (result.stdout + result.stderr).strip()
+    if result.returncode != 0 and output:
+        return f"(exit {result.returncode})\n{output}"
+    if result.returncode != 0:
+        return f"(exit {result.returncode})"
+    return output
 
 
 def update_top_phase_status(phase_dir_name: str, status: str) -> None:
@@ -147,6 +168,183 @@ def invoke_claude(prompt: str, output_path: Path) -> None:
         "recorded_at": now_iso(),
     }
     output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def invoke_claude_text(prompt: str) -> dict:
+    try:
+        result = subprocess.run(
+            ["claude", "-p", "--dangerously-skip-permissions", "--output-format", "json", prompt],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=1800,
+        )
+        return {
+            "exit_code": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "recorded_at": now_iso(),
+        }
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return {
+            "exit_code": 1,
+            "stdout": "",
+            "stderr": str(exc),
+            "recorded_at": now_iso(),
+        }
+
+
+def extract_json_object(text: str) -> dict:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```(?:json)?\s*", "", stripped)
+        stripped = re.sub(r"\s*```$", "", stripped).strip()
+
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(stripped):
+        if char != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(stripped[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            return value
+    raise json.JSONDecodeError("No JSON object found", stripped, 0)
+
+
+def parse_claude_review(raw: dict) -> dict:
+    stdout = raw.get("stdout", "")
+    payload = extract_json_object(stdout)
+    result_text = payload.get("result") if isinstance(payload.get("result"), str) else stdout
+    return extract_json_object(result_text)
+
+
+def as_list(value: object) -> list:
+    if isinstance(value, list):
+        return value
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+def latest_completed_step(index: dict) -> Optional[int]:
+    completed = [
+        step["step"]
+        for step in index.get("steps", [])
+        if step.get("status") == "completed" and isinstance(step.get("step"), int)
+    ]
+    if not completed:
+        return None
+    return max(completed)
+
+
+def build_review_prompt(phase_dir: Path, index: dict, step_number: int, guardrails: str) -> str:
+    step_file = phase_dir / f"step{step_number}.md"
+    template = REVIEW_PROMPT_FILE.read_text(encoding="utf-8")
+    status = run_capture(["git", "status", "--short"])
+    diff = run_capture(["git", "diff", "--", "."])
+
+    return "\n\n---\n\n".join(
+        [
+            template,
+            guardrails,
+            f"## Review Target\n\n- Phase: `{phase_dir.name}`\n- Step: `{step_number}`",
+            f"## Step Spec\n\n{step_file.read_text(encoding='utf-8')}",
+            f"## Phase Index\n\n```json\n{json.dumps(index, indent=2, ensure_ascii=False)}\n```",
+            f"## Git Status\n\n```text\n{status}\n```",
+            f"## Git Diff\n\n```diff\n{diff[-20000:]}\n```",
+        ]
+    )
+
+
+def write_correction_prompt(
+    correction_prompt_file: Path,
+    phase_dir: Path,
+    step_number: int,
+    blocking: list,
+    non_blocking: list,
+) -> None:
+    step_file = phase_dir / f"step{step_number}.md"
+    content = "\n\n".join(
+        [
+            "# Codex Correction Prompt",
+            "You are Codex. Perform exactly one correction pass for the blocking review issues below.",
+            "Do not run another Claude review automatically. After the correction, rerun the step Acceptance Criteria and `python3 scripts/verify.py`.",
+            f"## Phase\n\n`{phase_dir.name}`",
+            f"## Step\n\n`{step_number}`",
+            f"## Step Spec\n\n{step_file.read_text(encoding='utf-8')}",
+            f"## Blocking Issues\n\n```json\n{json.dumps(blocking, indent=2, ensure_ascii=False)}\n```",
+            f"## Non-Blocking Notes\n\n```json\n{json.dumps(non_blocking, indent=2, ensure_ascii=False)}\n```",
+        ]
+    )
+    correction_prompt_file.write_text(content + "\n", encoding="utf-8")
+
+
+def review_phase(phase_dir_name: str) -> int:
+    phase_dir = PHASES_DIR / phase_dir_name
+    index_file = phase_dir / "index.json"
+    if not phase_dir.exists() or not index_file.exists():
+        print(f"Phase not found: {phase_dir_name}", file=sys.stderr)
+        return 1
+    if not REVIEW_PROMPT_FILE.exists():
+        print(f"Review prompt not found: {relative_path(REVIEW_PROMPT_FILE)}", file=sys.stderr)
+        return 1
+
+    index = read_json(index_file)
+    step_number = latest_completed_step(index)
+    if step_number is None:
+        print(f"No completed step to review: {phase_dir_name}", file=sys.stderr)
+        return 1
+
+    review_file = phase_dir / f"step{step_number}-review.json"
+    correction_prompt_file = phase_dir / f"step{step_number}-correction-prompt.md"
+    if review_file.exists():
+        existing = read_json(review_file)
+        print(f"Review already exists: {relative_path(review_file)}")
+        return 1 if existing.get("verdict") == "needs_correction" else 0
+
+    prompt = build_review_prompt(phase_dir, index, step_number, load_guardrails())
+    print(f"Running Claude review for step {step_number}: {phase_dir_name}")
+    raw = invoke_claude_text(prompt)
+
+    correction_prompt_path: Optional[str] = None
+    try:
+        parsed = parse_claude_review(raw)
+        blocking = as_list(parsed.get("blocking"))
+        non_blocking = as_list(parsed.get("non_blocking"))
+        verdict = "needs_correction" if blocking else "pass"
+    except (json.JSONDecodeError, TypeError, AttributeError) as exc:
+        blocking = []
+        non_blocking = [
+            {
+                "reason": "Claude review output could not be parsed; treating as non-blocking.",
+                "error": str(exc),
+                "raw": raw,
+            }
+        ]
+        verdict = "pass"
+
+    if blocking:
+        if not correction_prompt_file.exists():
+            write_correction_prompt(correction_prompt_file, phase_dir, step_number, blocking, non_blocking)
+        correction_prompt_path = relative_path(correction_prompt_file)
+
+    review = {
+        "step": step_number,
+        "timestamp": now_iso(),
+        "verdict": verdict,
+        "blocking": blocking,
+        "non_blocking": non_blocking,
+        "correction_prompt_path": correction_prompt_path,
+    }
+    write_json(review_file, review)
+
+    print(f"Review artifact: {relative_path(review_file)}")
+    if verdict == "needs_correction":
+        print(f"Correction prompt: {correction_prompt_path}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def get_step(index: dict, step_number: int) -> dict:
@@ -254,8 +452,12 @@ def execute_phase(phase_dir_name: str) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Execute a phase directory.")
     parser.add_argument("phase", help="Phase directory name, e.g. 0-foundation")
+    parser.add_argument("--review", action="store_true", help="Run one Claude review after successful execution.")
     args = parser.parse_args()
-    return execute_phase(args.phase)
+    result = execute_phase(args.phase)
+    if result != 0 or not args.review:
+        return result
+    return review_phase(args.phase)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 목적

기존 `execute.py` 기반 구현 루프가 성공한 뒤 Claude 리뷰를 1회 수행하고, blocking issue가 있을 때 Codex가 사용할 correction prompt를 생성하도록 하네스 운영 루프를 확장합니다.

## 변경 내용

- `scripts/execute.py`에 `--review` 옵션을 추가했습니다.
- 성공한 phase 실행 이후 마지막 completed step 기준으로 `phases/<phase>/stepN-review.json`을 저장합니다.
- blocking issue가 있으면 `phases/<phase>/stepN-correction-prompt.md`를 생성하고 종료합니다.
- Claude는 리뷰만 수행하고 보정 구현은 Codex correction prompt로 분리했습니다.
- 자동 재리뷰 및 자동 보정 루프를 만들지 않았습니다.
- `phases/_review-prompt.md`와 `docs/HARNESS.md`에 운영 규칙을 추가했습니다.

## 영향 범위

하네스 실행 스크립트와 하네스 문서에만 영향을 줍니다. 앱 기능, UI, `verify.py`는 변경하지 않았습니다.

## 완료 조건

- `npm run typecheck` 통과
- `npm run lint` 통과
- `python3 scripts/verify.py` 통과
- `python3 scripts/execute.py _review-smoke --review`로 review artifact 생성 확인

Closes #7